### PR TITLE
Remove file-content resource

### DIFF
--- a/jukebox-api.raml
+++ b/jukebox-api.raml
@@ -119,33 +119,6 @@ traits:
     type:
       collection-item:
         exampleItem: !include jukebox-include-song-retrieve.sample
-    /file-content:
-      description: The file to be reproduced by the client
-      get:
-        description: Get the file content
-        responses:
-          200:
-            body:
-              binary/octet-stream:
-                example:
-                  !include heybulldog.mp3
-      post:
-        description: |
-           Enters the file content for an existing song entity.
-
-           The song needs to be created for the `/songs/{songId}/file-content` to exist.
-           You can use this second resource to get and post the file to reproduce.
-
-           Use the "binary/octet-stream" content type to specify the content from any consumer (excepting web-browsers).
-           Use the "multipart-form/data" content type to upload a file which content will become the file-content
-        body:
-          binary/octet-stream:
-          multipart/form-data:
-            formParameters:
-              file:
-                description: The file to be uploaded
-                required: true
-                type: file
 /artists:
   type:
     collection:


### PR DESCRIPTION
The mp3 that's referenced here doesn't exist in the repo, when using this RAML, it raises an error. As discussed with Christian Vogel, we're getting rid of the resource to avoid this issue
