### PR TITLE
Fixing typo; whitespace auto

### DIFF
--- a/jukebox-api.raml
+++ b/jukebox-api.raml
@@ -32,7 +32,7 @@ resourceTypes:
                 example: |
                   <<exampleCollection>>
       post:
-        description: | 
+        description: |
           Add a new <<resourcePathName|!singularize>> to Jukebox.
         queryParameters:
           access_token:
@@ -165,7 +165,7 @@ traits:
       type:
         readOnlyCollection:
           exampleCollection: !include jukebox-include-artist-albums.sample
-      description: Collection of albulms belonging to the artist
+      description: Collection of albums belonging to the artist
       get:
         description: Get a specific artist's albums list
         is: [orderable: {fieldsList: "albumName"}, pageable]


### PR DESCRIPTION
I don't know whether this is intentional, but I found a typo. I can take out the whitespace changes if you don't want them; my editor deletes trailing whitespace. 
